### PR TITLE
Refactor: 회원가입 도메인 로직을 서비스 로직에서 분리 #11

### DIFF
--- a/src/user/dto/sign-in.dto.ts
+++ b/src/user/dto/sign-in.dto.ts
@@ -4,7 +4,7 @@ import { User } from '../entities/user.entity';
 import { UserPassword } from '../entities/user-password.entity';
 
 export class SignInDto extends PickType(SignUpDto, ['email', 'password']) {
-  toUserPasswordEntity(): UserPassword {
+  toEntity(): UserPassword {
     return UserPassword.of(User.byEmail(this.email), this.password);
   }
 }

--- a/src/user/dto/sign-up.dto.ts
+++ b/src/user/dto/sign-up.dto.ts
@@ -1,3 +1,4 @@
+import { DateTimeUtil } from './../../util/date-time.utils';
 import { Gender } from '../../common/types/gender.type';
 import { ApiProperty } from '@nestjs/swagger';
 import { Expose, Type } from 'class-transformer';
@@ -11,6 +12,10 @@ import {
   MaxLength,
   MinLength,
 } from 'class-validator';
+import { User } from '../entities/user.entity';
+import { UserPassword } from '../entities/user-password.entity';
+import { UserProfile } from '../entities/user-profile.entity';
+import { SignUpProps } from '../user.service';
 
 export class SignUpDto {
   @Expose()
@@ -85,8 +90,21 @@ export class SignUpDto {
   })
   @Expose()
   @IsNotEmpty()
-  // @IsISO8601({ strict: true })
   @IsDate()
   @Type(() => Date)
   dateOfBirth: Date;
+
+  toEntity(): SignUpProps {
+    const user = User.create(this.email);
+    const userPassword = UserPassword.create(user, this.password);
+    const userProfile = UserProfile.create(
+      user,
+      this.name,
+      this.gender,
+      DateTimeUtil.getYear(this.dateOfBirth),
+      DateTimeUtil.getMonth(this.dateOfBirth),
+      DateTimeUtil.getDate(this.dateOfBirth),
+    );
+    return { user, userPassword, userProfile };
+  }
 }

--- a/src/user/entities/user-password.entity.ts
+++ b/src/user/entities/user-password.entity.ts
@@ -34,4 +34,8 @@ export class UserPassword extends EntityBase {
     userPassword.password = password;
     return userPassword;
   }
+
+  setHashedPassword(hashedPassword: string): void {
+    this.password = hashedPassword;
+  }
 }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -17,7 +17,7 @@ export class UserController {
   ): Promise<ResponseEntity<AccessTokenDto>> {
     return ResponseEntity.CREATED_WITH(
       '회원가입 요청에 성공하였습니다.',
-      await this.userService.signUp(dto),
+      await this.userService.signUp(dto.toEntity()),
     );
   }
 
@@ -27,7 +27,7 @@ export class UserController {
   ): Promise<ResponseEntity<AccessTokenDto>> {
     return ResponseEntity.CREATED_WITH(
       '로그인 요청에 성공하였습니다.',
-      await this.userService.signIn(dto.toUserPasswordEntity()),
+      await this.userService.signIn(dto.toEntity()),
     );
   }
 }


### PR DESCRIPTION
## PR 체크리스트

아래 항목을 확인해 주세요:

- [x] 커밋 메시지가 우리의 가이드라인을 따르고 있는지 확인하세요
- [ ] 변경 사항에 대한 테스트가 추가되었는지 확인하세요 (버그 수정 / 기능 추가)
- [ ] 문서가 추가되거나 업데이트되었는지 확인하세요 (버그 수정 / 기능 추가)

## PR 유형

이 PR은 어떤 종류의 변경을 가져오나요?

<!-- 이 PR에 해당하는 것을 "x"로 표시하세요. -->

- [ ] 버그 수정
- [ ] 새로운 기능 추가
- [ ] 코드 스타일 업데이트 (서식, 로컬 변수)
- [x] 리팩터링 (기능 변경 없음, API 변경 없음)
- [ ] 빌드 관련 변경
- [ ] CI 관련 변경
- [ ] 문서 내용 변경
- [ ] 애플리케이션 / 인프라 변경
- [ ] 기타... 설명:

## 관련 이슈

<!-- 관련된 이슈에 링크하세요. -->

이슈 번호: #11 

## 현재 동작은 무엇인가요?
- 기존 컨트롤러 signUp 메소드에서는 dto를 service 메소드의 인자로 넘김.
- 기존 서비스 signUp 메소드가 호출하는 saveUser 메소드에서 dto를 domain entity로 변환하는 코드가 작성되어 있음.

이것으로, dto와 service class의 강한 결합이 생기고 dto와 service, domain entity의 역할과 책임의 응집도가 떨어짐.

## 새로운 동작은 무엇인가요?
### service 클래스에 있는 dto -> entity 변환 코드를 분리하였습니다.
- dto를 entity로 변환하는 부분을 dto로 명확히 분리하여 dto의 책임(요청 변수들의 값 검증 및 엔티티로 변환)을 뚜렷히 하고, 외부 의존성 사용 및 트랜잭션 관리의 책임을 service 메소드에 두어  코드 응집력을 높임
- service 메소드는 dto의 타입을 몰라도 되도록, 컨트롤러에서 dto을 entity로 변환하여 service 메소드의 인자로 넘깁니다. 이로써, service 클래스와 dto, controller와의 강한 결합을 느슨하게 하였습니다.

## 이 PR은 호환성 변경을 도입하나요?

- [ ] 예
- [ ] 아니요

<!-- 이 PR에 호환성 변경이 포함되어 있다면, 기존 응용 프로그램에 대한 영향과 마이그레이션 경로를 아래에 설명해 주세요. -->

## 기타 정보
